### PR TITLE
fix sim 5.0 reset

### DIFF
--- a/scripts/evaluate_gn1.py
+++ b/scripts/evaluate_gn1.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from isaacsim import SimulationApp
+from isaaclab.app import AppLauncher
 
 import contextlib
 import torch
@@ -20,9 +22,6 @@ import tqdm
 from typing import Optional
 
 import tyro
-from isaacsim import SimulationApp
-
-from isaaclab.app import AppLauncher
 
 from config.args import Gr00tN1ClosedLoopArguments
 
@@ -78,7 +77,6 @@ def run_closed_loop_policy(
                 break
 
             # reset environment
-            env.sim.reset()
             env.reset(seed=args.seed)
 
             robot = env.scene["robot"]

--- a/source/isaaclab_eval_tasks/isaaclab_eval_tasks/tasks/manipulation/pick_place/exhaustpipe_gr1t2_closedloop_env_cfg.py
+++ b/source/isaaclab_eval_tasks/isaaclab_eval_tasks/tasks/manipulation/pick_place/exhaustpipe_gr1t2_closedloop_env_cfg.py
@@ -97,4 +97,4 @@ class ExhaustPipeGR1T2ClosedLoopEnvCfg(ExhaustPipeGR1T2BaseEnvCfg):
         # simulation settings
         self.sim.dt = 1 / 100
         self.decimation = 5
-        self.sim.render_interval = 2
+        self.sim.render_interval = 5

--- a/source/isaaclab_eval_tasks/isaaclab_eval_tasks/tasks/manipulation/pick_place/nutpour_gr1t2_closedloop_env_cfg.py
+++ b/source/isaaclab_eval_tasks/isaaclab_eval_tasks/tasks/manipulation/pick_place/nutpour_gr1t2_closedloop_env_cfg.py
@@ -94,4 +94,4 @@ class NutPourGR1T2ClosedLoopEnvCfg(NutPourGR1T2BaseEnvCfg):
         # simulation settings
         self.sim.dt = 1 / 100
         self.decimation = 5
-        self.sim.render_interval = 1
+        self.sim.render_interval = 5


### PR DESCRIPTION
Why: After the 1st pass of num_parallel_env, `env.sim.reset() `as it freezes `env.reset()`.

Fix: 
- Remove `env.sim.reset()` for now
- Sim 5.0 issue reported to Sim & Lab team, investigation WIP.