### PR TITLE
Add DGX Spark non-support note to docs

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 ## Pre-requisites
-- For [Policy Closed-loop Evaluation](#-policy-closed-loop-evaluation), we have tested on Ubuntu 22.04, GPU: L40, RTX 4090 and A6000 Ada, and Python==3.11, CUDA version 12.8. Blackwell has not be supported when running [GR00T](https://github.com/NVIDIA/Isaac-GR00T) models.
+- For [Policy Closed-loop Evaluation](#-policy-closed-loop-evaluation), we have tested on Ubuntu 22.04, GPU: L40, RTX 4090 and A6000 Ada, and Python==3.11, CUDA version 12.8. DGX Spark and Blackwell has not yet been supported when running [GR00T](https://github.com/NVIDIA/Isaac-GR00T) models.
 - For [Policy Post Training](#post-training), see [GR00T-N1 pre-requisites](https://github.com/NVIDIA/Isaac-GR00T?tab=readme-ov-file#prerequisites)
 - Please make sure you have the following dependencies installed in your system: `ffmpeg`, `libsm6`, `libxext6`
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -20,10 +20,9 @@ isaaclab 0.37.2 requires torch>=2.7, but you have torch 2.5.1 which is incompati
 isaacsim-core 5.0.0 requires torch==2.7.0, but you have torch 2.5.1 which is incompatible.
 </pre>
 
-## Running on Blackwell GPUs
+## Running on DGX Spark and Blackwell GPUs
 
-Unfortunately, due to limited support of flash attention module (by May 2025), GR00T policy can only support running on non-Blackwell GPUs. However
-you can run Mimic-related data generation workflows and GR00T-Lerobot data conversion on Blackwell. Blackwell support is coming soon.
+Unfortunately, due to limited support of flash attention module (by May 2025), GR00T policy is not supported on DGX Spark and Blackwell GPUs. However you can run Mimic-related data generation workflows and GR00T-Lerobot data conversion on Blackwell. Blackwell support is coming soon.
 
 ## Running evaluation on Multiple GPUs
 


### PR DESCRIPTION
Add note stating that DGX Spark is not currently supported with the GR00T policy.